### PR TITLE
Remove FAIL_IF_MISSING_LABEL so default label can attached to PR

### DIFF
--- a/.github/workflows/validate-version-label.yml
+++ b/.github/workflows/validate-version-label.yml
@@ -6,5 +6,3 @@ on:
 jobs:
   validate:
     uses: vechain/github-actions/.github/workflows/validate-pr-label.yaml@v.1.1.6
-    with:
-      FAIL_IF_MISSING_LABEL: true


### PR DESCRIPTION
we would like to add default label to create tag creation used for deployment.

label to be `increment:patch `

issue : #87 