### PR TITLE
hotfix: update ignore_command condition based on terraform workspace

### DIFF
--- a/terraform/vercel-frontend.tf
+++ b/terraform/vercel-frontend.tf
@@ -12,7 +12,7 @@ resource "vercel_project" "vevote_frontend" {
   build_command    = terraform.workspace == "prod" ? "yarn build:mainnet" : "yarn build:staging"
   output_directory = "frontend/dist"
   dev_command      = terraform.workspace == "prod" ? "yarn dev:mainnet" : "yarn dev:staging"
-  ignore_command   = "[ \"$VERCEL_ENV\" != \"production\" ]"
+  ignore_command   = terraform.workspace == "prod" ? "[ \"$VERCEL_ENV\" != \"production\" ]" : ""
   environment = terraform.workspace == "prod" ? [
     {
       key    = "VECHAIN_URL_DEVNET"


### PR DESCRIPTION
what I did was I did not have a condition so this ignore build applied to both [vevote-frontend-prod](https://vercel.com/vechain-foundation/vevote-frontend-prod/settings/git) & [vevote-frontend-dev](https://vercel.com/vechain-foundation/vevote-frontend-dev/settings/git) (should be automatic).

The idea is:
When `VERCEL_ENV is "production"`, the condition fails, returning `exit code 1`. This signals that a new build should be issued.
For any environment such as `Preview`, the condition succeeds (exit code 0), and the build step is ignored.

issue: [#94](https://github.com/vechain/vevote/issues/94)