### PR TITLE
Improve CI/CD: Enable auto-labeling and Vercel preview deployments for mainnet 

### DIFF
--- a/.github/workflows/codebase-versioning.yml
+++ b/.github/workflows/codebase-versioning.yml
@@ -6,11 +6,6 @@ on:
       - main
     types: [closed]
 
-  workflow_call:
-    secrets:
-      DEPLOY_KEY:
-        required: true
-
 jobs:
   auto-versioning:
     permissions:

--- a/.github/workflows/validate-version-label.yml
+++ b/.github/workflows/validate-version-label.yml
@@ -1,7 +1,8 @@
-permissions:
-  issues: write
 name: Validate PR Label
 
+permissions:
+  issues: write
+  pull-requests: write
 on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
@@ -42,6 +43,7 @@ jobs:
         if: ${{ !inputs.FAIL_IF_MISSING_LABEL && steps.label-check.outputs.label_missing == 'true' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               owner: context.repo.owner,

--- a/.github/workflows/validate-version-label.yml
+++ b/.github/workflows/validate-version-label.yml
@@ -5,7 +5,7 @@ permissions:
   pull-requests: write
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize, converted_to_draft]
   workflow_call:
     inputs:
       FAIL_IF_MISSING_LABEL:

--- a/terraform/vercel/vercel-frontend.tf
+++ b/terraform/vercel/vercel-frontend.tf
@@ -12,7 +12,6 @@ resource "vercel_project" "vevote_frontend" {
   build_command    = terraform.workspace == "prod" ? "yarn build:mainnet" : "yarn build:staging"
   output_directory = "frontend/dist"
   dev_command      = terraform.workspace == "prod" ? "yarn dev:mainnet" : "yarn dev:staging"
-  ignore_command   = terraform.workspace == "prod" ? "[ \"$VERCEL_ENV\" != \"production\" ]" : ""
   environment = terraform.workspace == "prod" ? [
     {
       key    = "VECHAIN_URL_DEVNET"


### PR DESCRIPTION
Changes:

1- **Auto-labeling for PRs**: Added GitHub token and proper permissions to the validate-version-label workflow to ensure PRs automatically receive the increment:patch label when no version label is specified.

2- **Enable Vercel preview deployments**: Removed the `ignore_command` from the Terraform configuration for the mainnet project, allowing Vercel to automatically create preview deployments for all PRs.

 Removed unnecessary `workflow_call` secrets section from the validate-version-label workflow since it's not being called by other workflows.